### PR TITLE
:spider_web: Corrects `.svg` file paths

### DIFF
--- a/Challenge.html
+++ b/Challenge.html
@@ -21,16 +21,16 @@
     users as you engage in genuine discussion</p>
     <button type="button" id="secondButton" name="button">Get Started for Free</button>
   </div>
-<img id="firstImage" src="screen-mockups.svg" alt="screen mockups" >
+<img id="firstImage" src="images/screen-mockups.svg" alt="screen mockups" >
 
 <div class="row">
   <div class="column">
-    <img id="secondImage" src="icon-communities.svg" alt="">
+    <img id="secondImage" src="images/icon-communities.svg" alt="">
     <p id="firstNumber">1.4k+</p>
     <p id="numbDesc">Communities Formed</p>
   </div>
   <div class="column">
-    <img id="thirdImage" src="icon-messages.svg" alt="">
+    <img id="thirdImage" src="images/icon-messages.svg" alt="">
     <p id="secondNumber">2.7m+</p>
 
     <p id="mesgDesc">Messages sent</p>
@@ -39,7 +39,7 @@
 
 <div class="row">
   <div class="column">
-    <img id="fourthImage" src="illustration-grow-together.svg" alt="">
+    <img id="fourthImage" src="images/illustration-grow-together.svg" alt="">
 
   </div>
   <div class="column">
@@ -53,7 +53,7 @@
 <div class="row">
 
   <div class="column">
-      <img id="fifthImage" src="illustration-flowing-conversation.svg" alt="">
+      <img id="fifthImage" src="images/illustration-flowing-conversation.svg" alt="">
   </div>
   <div class="column">
     <h3>Flowing conversations</h3>
@@ -64,7 +64,7 @@
 
 <div class="row">
   <div class="column">
-    <img src="illustration-your-users.svg" alt="">
+    <img src="images/illustration-your-users.svg" alt="">
   </div>
   <div class="column">
     <h3>Your Users</h3>
@@ -84,10 +84,10 @@
     <button type="button" name="subsButton">Subscribe</button>
   </div>
   <div class="column">
-    <img src="logo.svg" alt="">
+    <img src="images/logo.svg" alt="">
     <p>Free Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris nulla quam, hendrerit lacinia vestibulum a, ultrices quis sem.</p>
-    <p> <img src="icon-phone.svg" alt="">Phone: +1-543-123-4567</p>
-    <p> <img src="icon-email.svg" alt="">example@huddle.com</p>
+    <p> <img src="images/icon-phone.svg" alt="">Phone: +1-543-123-4567</p>
+    <p> <img src="images/icon-email.svg" alt="">example@huddle.com</p>
   </div>
 </div>
 


### PR DESCRIPTION
Note for the future; for accessibility it's a good idea to also write a 
description for each image within the `alt=""` attribute, eg...


**This**


```html
<p> <img src="images/icon-phone.svg" alt="phone icon">Phone: 
+1-543-123-4567</p>
```


**Not**


```html
<p> <img src="images/icon-phone.svg" alt="">Phone: +1-543-123-4567</p>
```


... this is because there many online that use screen-readers and other 
technologies that'll clue people in to the context via these HTML 
attributes.